### PR TITLE
fix(replication): timeout

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -249,7 +249,7 @@ def replicate_couchdb_server(source_url, target_url, ignore_dbs=[]):
 
 
 def replicate_one_database(args):
-    timeout = 3
+    timeout = 10
 
     source_url, target_url, db = args
 


### PR DESCRIPTION
I often have following errors in a 'not so bad' computer:
`replicated database has xx docs, source has yy`.

After increasing the replication timeout a bit, thoses errors disappear.

So I propose to increase the timeout value from 3 to 10 seconds.