### PR TITLE
feat(CouchDB): Try to increase performance with update_lru_on_read

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -161,6 +161,7 @@ class CouchDBInstance(object):
                     'database_dir = %s\n' % self.datadir +
                     'view_index_dir = %s\n' % self.datadir +
                     'max_dbs_open = 2000\n'
+                    'update_lru_on_read = false\n'
                     '\n'
                     '[cluster]\n'
                     'q=1\n'  # ideal for a small, 1-node setup


### PR DESCRIPTION
1. According to couchdb's docs [2] and a couchdb's maintainer [1]:
   > If you expect to be running with a lot of databases, you may also
   > want to set this in your local.ini:
   >     [couchdb]
   >     update_lru_on_read = false

   > This has lead to significant performance enhancements on very busy
   > clusters.

2. This new conf (`update_lru_on_read = false`) is the default since
   version 2.2.

As the `restore` operation can failed a lot due to performance issue, I propose
to set this option.
It makes no arm and could improve performance for people using coucharchive with
couchdb version < 2.2.

[1]: apache/couchdb#1093 (comment)
[2]: http://docs.couchdb.org/en/2.2.0/whatsnew/2.2.html#id1