### PR TITLE
Use a dynamic replication speed

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -31,6 +31,9 @@ import urllib.request
 import couchdb
 
 
+NUMBER_OF_WORKERS = 64
+
+
 def _check_couchdb_connection(url):
     url = url if url.startswith('http://') else 'http://' + url
 
@@ -223,6 +226,36 @@ class CouchDBInstance(object):
         self.thread = None
 
 
+# Create a throttler object that can be safely shared between processes
+manager = multiprocessing.Manager()
+throttler = manager.Namespace()
+throttler.lock = manager.Lock()
+throttler.delay = 0
+
+
+def get_throttler_delay():
+    global throttler
+    with throttler.lock:
+        return throttler.delay
+
+
+def make_throttler_slower():
+    global throttler
+    with throttler.lock:
+        if throttler.delay >= 1:
+            throttler.delay *= 2
+        else:
+            throttler.delay += 1
+        throttler.delay = min(60, throttler.delay)  # stay within [0, 1 min]
+
+
+def make_throttler_faster():
+    global throttler
+    with throttler.lock:
+        # Value chosen so that NUMBER_OF_WORKERS successes compensate 1 failure
+        throttler.delay /= 2 ** (1.0 / NUMBER_OF_WORKERS)
+
+
 def replicate_couchdb_server(source_url, target_url, ignore_dbs=[]):
     while source_url.endswith('/'):
         source_url = source_url[:-1]
@@ -235,7 +268,7 @@ def replicate_couchdb_server(source_url, target_url, ignore_dbs=[]):
 
     todos = [(source_url, target_url, db) for db in all_dbs]
 
-    pool = multiprocessing.Pool(processes=16)
+    pool = multiprocessing.Pool(processes=NUMBER_OF_WORKERS)
     try:  # see https://stackoverflow.com/a/25791961
         list(pool.imap_unordered(replicate_one_database, todos))
     except Exception as e:
@@ -249,6 +282,8 @@ def replicate_couchdb_server(source_url, target_url, ignore_dbs=[]):
 
 
 def replicate_one_database(args):
+    time.sleep(get_throttler_delay())
+
     retries = 10
 
     source_url, target_url, db = args
@@ -282,7 +317,8 @@ def replicate_one_database(args):
         except socket.gaierror as e:
             if retries == 0:
                 raise e
-            time.sleep(1)
+            make_throttler_slower()
+            time.sleep(get_throttler_delay())
             retries -= 1
         except couchdb.http.ServerError as e:
             if retries == 0:
@@ -290,7 +326,8 @@ def replicate_one_database(args):
                     print('Retry with a greater ulimit '
                           '(e.g. `ulimit -n 8192`)', file=sys.stderr)
                 raise
-            time.sleep(1)
+            make_throttler_slower()
+            time.sleep(get_throttler_delay())
             retries -= 1
 
     while True:
@@ -301,10 +338,13 @@ def replicate_one_database(args):
             raise Exception(
                 '%s: replicated database has %d docs, source has %d'
                 % (db, target_len, source_len))
-        time.sleep(1)
+        make_throttler_slower()
+        time.sleep(get_throttler_delay())
         retries -= 1
 
     print('%s: done' % db)
+
+    make_throttler_faster()
 
 
 def create(source, filename, ignore_dbs=[]):

--- a/coucharchive
+++ b/coucharchive
@@ -249,7 +249,7 @@ def replicate_couchdb_server(source_url, target_url, ignore_dbs=[]):
 
 
 def replicate_one_database(args):
-    timeout = 10
+    retries = 10
 
     source_url, target_url, db = args
 
@@ -280,29 +280,29 @@ def replicate_one_database(args):
             target_db.security = source_db.security
             break
         except socket.gaierror as e:
-            if timeout == 0:
+            if retries == 0:
                 raise e
             time.sleep(1)
-            timeout -= 1
+            retries -= 1
         except couchdb.http.ServerError as e:
-            if timeout == 0:
+            if retries == 0:
                 if e.args[0][1][1] in ('no_majority', 'no_ring'):
                     print('Retry with a greater ulimit '
                           '(e.g. `ulimit -n 8192`)', file=sys.stderr)
                 raise
             time.sleep(1)
-            timeout -= 1
+            retries -= 1
 
     while True:
         source_len, target_len = len(source_db), len(target_db)
         if source_len == target_len:
             break
-        elif timeout == 0:
+        elif retries == 0:
             raise Exception(
                 '%s: replicated database has %d docs, source has %d'
                 % (db, target_len, source_len))
         time.sleep(1)
-        timeout -= 1
+        retries -= 1
 
     print('%s: done' % db)
 


### PR DESCRIPTION
### refactor(replication): Use a better variable name for `retries`

---

### feat(replication): Use a dynamic replication speed

Use an exponential backoff algorithm in order to modulate the speed of
replication. In practice, this means:
1. Use a large number of replication workers (64 instead of 16).
2. Sleep a while before every database replication, and also sleep a
   while in case of an error. The sleeping time ("delay") is dynamic:
   - whenever an error occurs, it is multiplied by two,
   - whenever a database replication successfully finishes, it is
     slightly reduced (currently by ~ 1.0109).

I've done some experiments to show the performance. These measured the
execution time of making a backup from a CouchDB server:

|                                     |  BEFORE |   AFTER |
|-------------------------------------|---------|---------|
| 1-node, on my laptop, 500 dbs       | 0:01:28 | 0:00:26 |
| 3-node cluster, from AWS, 500 dbs   | 0:01:44 | 0:00:44 |
| 3-node cluster, from AWS, 2000 dbs  | 0:07:05 | 0:03:02 |
