### PR TITLE
Fix growing db on replication

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -304,7 +304,10 @@ def bug_1418_create_missing_documents(source_db, target_db):
 
     for doc_id in missing_documents:
         source_info = source_db.get(doc_id, revs_info=True)['_revs_info']
-        target_doc = target_db.get(doc_id, revs=True, open_revs='all')[0]['ok']
+        target_doc = target_db.get(doc_id, revs=True, open_revs='all')
+        if not target_doc:
+            continue  # not bug #1418
+        target_doc = target_doc[0]['ok']
         if not target_doc['_deleted']:
             continue  # not bug #1418
         common_ancestor = target_doc['_rev']  # e.g. '6-0ebc2b61b51eb4ed'
@@ -393,6 +396,9 @@ def replicate_one_database(args):
             time.sleep(get_throttler_delay())
             retries -= 1
 
+    # Check if source and target have the same number of documents. If not, it
+    # can be explained by two reasons: source db had a new document created
+    # during replication, or bug #1418 happened.
     while True:
         try:
             source_len, target_len = len(source_db), len(target_db)
@@ -401,6 +407,7 @@ def replicate_one_database(args):
             elif source_len > target_len:
                 # Overcome bug https://github.com/apache/couchdb/issues/1418
                 bug_1418_create_missing_documents(source_db, target_db)
+                server.replicate(source_url + '/' + db, target_url + '/' + db)
         except couchdb.http.ServerError as e:
             pass
 

--- a/coucharchive
+++ b/coucharchive
@@ -394,12 +394,16 @@ def replicate_one_database(args):
             retries -= 1
 
     while True:
-        source_len, target_len = len(source_db), len(target_db)
-        if source_len == target_len:
-            break
-        elif source_len > target_len:
-            # Overcome bug https://github.com/apache/couchdb/issues/1418
-            bug_1418_create_missing_documents(source_db, target_db)
+        try:
+            source_len, target_len = len(source_db), len(target_db)
+            if source_len == target_len:
+                break
+            elif source_len > target_len:
+                # Overcome bug https://github.com/apache/couchdb/issues/1418
+                bug_1418_create_missing_documents(source_db, target_db)
+        except couchdb.http.ServerError as e:
+            pass
+
         if retries == 0:
             raise Exception(
                 '%s: replicated database has %d docs, source has %d'


### PR DESCRIPTION
### fix(replication): Handle server error on len(db)

To prevent this error we had recently:

      File "/usr/bin/coucharchive", line 397, in replicate_one_database
        source_len, target_len = len(source_db), len(target_db)
      ...
      File "/usr/lib/python3.6/site-packages/couchdb/http.py", line 429, in request
        raise ServerError((status, error))
    couchdb.http.ServerError: (500, ('internal_server_error', 'No DB shards could be opened.'))

---

### fix(replication): Don't crash on handling bug 1418 if missing doc

This commit fixes the code that handles bug #1418, it a special case
where the source database is growing (a new document was created during
replication). In such cases, `bug_1418_create_missing_documents()`
should check whether the missing document ever existed or not. If not,
it is not bug #1418 (previously coucharchive crashed with `TypeError:
'NoneType' object is not subscriptable`). In this case, a new repliction
should be attempted.

The bug can be easily reproduced with:

```
[terminal 0] coucharchive load -i ~/backup-500-dbs.tar.gz
[terminal 1] i=0; while true; do ((i++)); curl -X PUT $COUCH/$DB/test-$i -d '{}'; sleep 0.1; done
[terminal 2] coucharchive create --from $COUCH -o /dev/null
```