### PR TITLE
feat(replication): Don't create checkpoints

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -169,6 +169,9 @@ class CouchDBInstance(object):
                     'q=1\n'  # ideal for a small, 1-node setup
                     'n=1\n'
                     '\n'
+                    '[replicator]\n'
+                    'use_checkpoints = false\n'  # only one-shot replications
+                    '\n'
                     '[admins]\n'
                     '%s = %s\n' % self.creds)
 


### PR DESCRIPTION
Set `use_checkpoints = false` in the `[replicator]` conf of the
temporary CouchDB instance. There is no need to create checkpoints,
since the script performs one-shot replications that aren't supposed to
be resumed later.