### PR TITLE
feat(CouchDB): Try to avoid requests timeout on replication

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -171,6 +171,7 @@ class CouchDBInstance(object):
                     '\n'
                     '[replicator]\n'
                     'use_checkpoints = false\n'  # only one-shot replications
+                    'connection_timeout = 120000'  # try to avoid req_timedout
                     '\n'
                     '[admins]\n'
                     '%s = %s\n' % self.creds)


### PR DESCRIPTION
After many failed nightly replication jobs we ended up trying many
different configuration options.

Our tests showed that using a pretty high value for `connection_timeout`
resulted in less crashes on errors like:
```
couchdb.http.ServerError: (500, ('error', '{worker_died,<0.3662.0>,\n
{process_died,<0.8932.13>,\n {http_request_failed,"POST",\n
"http://localhost:46569/_users/_bulk_docs",\n
{error,{error,req_timedout}}}}}'))
```

Let's use a value of `120000` seconds.

See the CouchDB documentation ([1]) for more explanation on this parameter.

[1]: https://docs.couchdb.org/en/latest/config/replicator.html#replicator/connection_timeout