### PR TITLE
fix(CouchDB): Add newline character after connection timeout option

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -171,7 +171,7 @@ class CouchDBInstance(object):
                     '\n'
                     '[replicator]\n'
                     'use_checkpoints = false\n'  # only one-shot replications
-                    'connection_timeout = 120000'  # try to avoid req_timedout
+                    'connection_timeout = 120000\n'  # avoid req_timedout
                     '\n'
                     '[admins]\n'
                     '%s = %s\n' % self.creds)


### PR DESCRIPTION
Commit a8d764e76 did not had a `\n` character at the end of the new
option it introduced for CouchDB.

Let's fix that.