### PR TITLE
feat(CouchDB): Limit number of replication worker processes

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -172,6 +172,7 @@ class CouchDBInstance(object):
                     '[replicator]\n'
                     'use_checkpoints = false\n'  # only one-shot replications
                     'connection_timeout = 120000\n'  # avoid req_timedout
+                    'worker_processes = 1\n'
                     '\n'
                     '[admins]\n'
                     '%s = %s\n' % self.creds)


### PR DESCRIPTION
Following commit a8d764e768 let's also limit the number of worker
processes (see [1]).

Our tests showed that by using a lower value (1 instead of 4)
backups are more likely to succeed.

An explanation to this can be that `coucharchive` runs **many**
replication at the same time and is already managing by itself the
number of workers it needs to run smoothly.

[1]: https://docs.couchdb.org/en/latest/config/replicator.html#replicator/worker_processes