### PR TITLE
feat(script): add output help when archive cannot un-tar in `tmp`

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -468,7 +468,15 @@ def _load_archive(filename, callback):
     with tarfile.open(filename) as tar, \
             tempfile.TemporaryDirectory(prefix='coucharchive-') as tmp:
         print('Extracting backup archive from %s' % filename, file=sys.stderr)
-        tar.extractall(path=tmp)
+        try:
+            tar.extractall(path=tmp)
+        except OSError as e:
+            if e.args[0] == 28:
+                print('Exception catched: OSError: ' + str(e), file=sys.stderr)
+                print('Try to increase the size of your `/tmp` folder',
+                      file=sys.stderr)
+                exit(1)
+            raise
 
         if os.path.isfile(tmp + '/erlang_node_name'):
             with open(tmp + '/erlang_node_name', 'r') as f:


### PR DESCRIPTION
During archive un-tar, if `No space left on device` is raised, propose user to
raise the size of his `/tmp` folder.
(I firmly believed, for a couple of hours, that I had a RAM issue).
On Fedora, a command to raise the size of the temporary folder until the next
reboot is:
```
sudo mount -o remount,size=20G,noatime /tmp
```