### PR TITLE
chore(deps): bump to python CouchDB version 1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
 
     scripts=['coucharchive'],
     install_requires=[
-        'CouchDB >=1.0.1',
+        'CouchDB >=1.2.0',
     ],
 )


### PR DESCRIPTION
Release on february 9, 2018:
https://couchdb-python.readthedocs.io/en/latest/changes.html#version-1-2-2018-02-09