### PR TITLE
feat(script): Add ISO 8601 timestamp in log

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -703,7 +703,9 @@ def main():
 
     # https://docs.python.org/fr/3/library/logging.html#levels
     loglevel = 10 * (2 + (args.quiet or 0) - (args.verbose or 0))
-    logging.basicConfig(format='%(levelname)s: %(message)s', level=loglevel)
+    logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
+                        datefmt="%Y-%m-%dT%H:%M:%S%z",
+                        level=loglevel)
 
     config = configparser.ConfigParser()
     if args.config_file:


### PR DESCRIPTION
Looks like that:
```
...
2019-12-17T15:34:09+0100 DEBUG: Currently running 4 replication workers
2019-12-17T15:34:09+0100 DEBUG: Ideal speed = fastest; current average speed = 0.0 rep/s
2019-12-17T15:34:10+0100 DEBUG: Currently running 4 replication workers
2019-12-17T15:34:10+0100 DEBUG: Ideal speed = fastest; current average speed = 0.0 rep/s
2019-12-17T15:34:11+0100 DEBUG: Currently running 4 replication workers
2019-12-17T15:34:11+0100 DEBUG: Ideal speed = fastest; current average speed = 0.0 rep/s
...
```