### PR TITLE
fix(replication): Performance drop following v2.2.0

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -253,26 +253,43 @@ class ReplicationControl(object):
         self.ideal_speed = 0
         self.current_avge_speed = 0
 
-        self._last_successes = multiprocessing.Manager().list()
-        self._last_errors = multiprocessing.Manager().list()
+        self._last_successes_reported = multiprocessing.Queue()
+        self._last_successes = []
+        self._last_errors_reported = multiprocessing.Queue()
+        self._last_errors = []
 
     def report_success(self):
-        self._last_successes.append((int(time.time()),
-                                     self.running_replications.value))
+        self._last_successes_reported.put((int(time.time()),
+                                           self.running_replications.value))
 
     def report_error(self):
-        self._last_errors.append((int(time.time()),
-                                  self.running_replications.value))
+        self._last_errors_reported.put((int(time.time()),
+                                        self.running_replications.value))
 
-    def _drop_old_events(self):
+    def _clean_and_read_events(self):
+        reported = []
+        while True:
+            try:
+                reported.append(self._last_successes_reported.get_nowait())
+            except queue.Empty:
+                break
+        self._last_successes += reported
+        reported = []
+        while True:
+            try:
+                reported.append(self._last_errors_reported.get_nowait())
+            except queue.Empty:
+                break
+        self._last_errors += reported
+
         ten_min_ago = time.time() - 10 * 60
-        self._last_successes[:] = [e for e in self._last_successes
-                                   if e[0] > ten_min_ago]
-        self._last_errors[:] = [e for e in self._last_errors
+        self._last_successes = [e for e in self._last_successes
                                 if e[0] > ten_min_ago]
+        self._last_errors = [e for e in self._last_errors
+                             if e[0] > ten_min_ago]
 
     def recent_errors(self):
-        self._drop_old_events()
+        self._clean_and_read_events()
         return len(self._last_errors)
 
     def _ideal_number_of_replications_for_ideal_duration(self):
@@ -303,7 +320,7 @@ class ReplicationControl(object):
             return min(ideal_number, 2 * best_successful_number)
 
     def ideal_number_of_replications(self):
-        self._drop_old_events()
+        self._clean_and_read_events()
 
         # Choose the value to achieve replication in ideal_duration:
         ideal_number = self._ideal_number_of_replications_for_ideal_duration()
@@ -344,7 +361,7 @@ class ReplicationControl(object):
         return ideal_number
 
     def ideal_sleep_value(self):
-        self._drop_old_events()
+        self._clean_and_read_events()
 
         # If there was 1 error within last 5 minutes, pause for 5 seconds,
         # if there were 2 errors within last 5 minutes, pause for 10 seconds,


### PR DESCRIPTION
Following commit [`feat(replication): Implement queues and replication
controller`], with a `MAX_NUMBER_OF_WORKERS = 64` configuration, performance
have dropped.
It is said in the commit that the script will take ~15% more time.
But, in production, with ~70k small dbs, we see a worse increase of ~26%.

Re-doing the test of [`feat(replication): Implement queues and replication
controller`], I see that part of the drop is due to
`ideal_number_of_replications()` computation, and part is not explained yet.

For that first part, the issue seems to be the use of shared
`multiprocessing.Manager().list()` arrays between process.
[It's something that is not recommended in the documentation], the recommended
way is to use `multiprocessing.Queues`, and it helps indeed recover part of the
performance lost (3000 small dbs):
- v2.1.6:
  - 28,26s user 6,72s system 23% cpu 2:26,89 total
  - 27,87s user 6,67s system 23% cpu 2:26,45 total
- this PR*:
  - 20,33s user 3,63s system 14% cpu 2:50,55 total
  - 20,09s user 3,69s system 14% cpu 2:47,32 total
- v2.2.1*:
  - 61,94s user 18,05s system 40% cpu 3:19,44 total
  - 61,81s user 17,80s system 39% cpu 3:21,01 total

*For this PR and v2.2.1 tests the following patch is used so results can be
compared to v2.1.6:
```diff
--- a/coucharchive
+++ b/coucharchive
@@ -34,7 +34,7 @@ import urllib.request
 import couchdb

-MAX_NUMBER_OF_WORKERS = 128
+MAX_NUMBER_OF_WORKERS = 64

 def _canonical_couchdb_url(url):
@@ -296,7 +296,7 @@ class ReplicationControl(object):
         if not len(self._last_successes):
             # We do not have enough data yet to return anything useful.
             # Start with 4 concurrent replications:
-            return 4
+            return 64
         else:
             # Compute the ideal number of concurrent replications, to finish in
             # ideal_duration:
```

[It's something that is not recommended in the documentation]: https://docs.python.org/fr/3/library/multiprocessing.html#sharing-state-between-processes
[`feat(replication): Implement queues and replication controller`]: https://github.com/adrienverge/coucharchive/commit/45fbdd5