### PR TITLE
fix(replication): Performance drop following v2.2.0 part 2

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -390,6 +390,7 @@ def replicate_couchdb_server(source_url, target_url,
                                 (in_queue, out_queue, control, source_url,
                                  target_url, reuse_db_if_exist))
     error = None
+    last_log = time.time()
 
     while len(dbs) and not error:
         ideal = control.ideal_number_of_replications()
@@ -397,18 +398,22 @@ def replicate_couchdb_server(source_url, target_url,
             in_queue.put(dbs.pop(0))
             control.running_replications.value += 1
 
-        logging.debug('Currently running %d replication workers'
-                      % control.running_replications.value)
-        logging.debug('Ideal speed = ' + ('%.1f rep/s' % control.ideal_speed
-                                          if ideal_duration else 'fastest') +
-                      '; current average speed = %.1f rep/s' %
-                      control.current_avge_speed)
-        n = control.recent_errors()
-        if n:
-            logging.debug(('There were %d CouchDB errors encountered in the '
-                           'last 5 minutes') % n)
+        # No more than one log per second:
+        if time.time() > last_log + 1:
+            last_log = time.time()
+            logging.debug('Currently running %d replication workers'
+                          % control.running_replications.value)
+            logging.debug('Ideal speed = ' +
+                          ('%.1f rep/s' % control.ideal_speed
+                           if ideal_duration else 'fastest') +
+                          '; current average speed = %.1f rep/s' %
+                          control.current_avge_speed)
+            n = control.recent_errors()
+            if n:
+                logging.debug(('There were %d CouchDB errors encountered in '
+                               'the last 5 minutes') % n)
 
-        time.sleep(1)
+        time.sleep(.1)
 
         while True:
             try:

--- a/coucharchive
+++ b/coucharchive
@@ -253,26 +253,43 @@ class ReplicationControl(object):
         self.ideal_speed = 0
         self.current_avge_speed = 0
 
-        self._last_successes = multiprocessing.Manager().list()
-        self._last_errors = multiprocessing.Manager().list()
+        self._last_successes_reported = multiprocessing.Queue()
+        self._last_successes = []
+        self._last_errors_reported = multiprocessing.Queue()
+        self._last_errors = []
 
     def report_success(self):
-        self._last_successes.append((int(time.time()),
-                                     self.running_replications.value))
+        self._last_successes_reported.put((int(time.time()),
+                                           self.running_replications.value))
 
     def report_error(self):
-        self._last_errors.append((int(time.time()),
-                                  self.running_replications.value))
+        self._last_errors_reported.put((int(time.time()),
+                                        self.running_replications.value))
 
-    def _drop_old_events(self):
+    def _clean_and_read_events(self):
+        reported = []
+        while True:
+            try:
+                reported.append(self._last_successes_reported.get_nowait())
+            except queue.Empty:
+                break
+        self._last_successes += reported
+        reported = []
+        while True:
+            try:
+                reported.append(self._last_errors_reported.get_nowait())
+            except queue.Empty:
+                break
+        self._last_errors += reported
+
         ten_min_ago = time.time() - 10 * 60
-        self._last_successes[:] = [e for e in self._last_successes
-                                   if e[0] > ten_min_ago]
-        self._last_errors[:] = [e for e in self._last_errors
+        self._last_successes = [e for e in self._last_successes
                                 if e[0] > ten_min_ago]
+        self._last_errors = [e for e in self._last_errors
+                             if e[0] > ten_min_ago]
 
     def recent_errors(self):
-        self._drop_old_events()
+        self._clean_and_read_events()
         return len(self._last_errors)
 
     def _ideal_number_of_replications_for_ideal_duration(self):
@@ -303,7 +320,7 @@ class ReplicationControl(object):
             return min(ideal_number, 2 * best_successful_number)
 
     def ideal_number_of_replications(self):
-        self._drop_old_events()
+        self._clean_and_read_events()
 
         # Choose the value to achieve replication in ideal_duration:
         ideal_number = self._ideal_number_of_replications_for_ideal_duration()
@@ -344,7 +361,7 @@ class ReplicationControl(object):
         return ideal_number
 
     def ideal_sleep_value(self):
-        self._drop_old_events()
+        self._clean_and_read_events()
 
         # If there was 1 error within last 5 minutes, pause for 5 seconds,
         # if there were 2 errors within last 5 minutes, pause for 10 seconds,


### PR DESCRIPTION
Based on https://github.com/adrienverge/coucharchive/pull/28

---
Following commit [`feat(replication): Implement queues and replication
controller`], with a `MAX_NUMBER_OF_WORKERS = 64` configuration, performance
have dropped.
It is said in the commit that the script will take ~15% more time.
But, in production, with ~70k small dbs, we see a worse increase of ~26%.

Re-doing the test of [`feat(replication): Implement queues and replication
controller`], I see that first part of the drop is due to
`ideal_number_of_replications()` computation, and the second part is due
to delay introduce by the main loop.

This commit fix the second part by reducing the sleeping time of the main loop.
Result on a 3k small dbs cluster:
- v2.1.6:
  - 28,44s user 6,77s system 24% cpu 2:26,02 total
  - 28,13s user 6,68s system 23% cpu 2:28,11 total
- this PR*:
  - 21,98s user 3,83s system 17% cpu 2:25,52 total
  - 22,44s user 3,79s system 17% cpu 2:27,15 total
- previous commit (v2.2.1+first part of the fix)*:
  - 20,03s user 3,65s system 13% cpu 2:50,08 total
  - 20,02s user 3,63s system 14% cpu 2:48,63 total

*For this PR and previous commit tests the following patch is used so results
can be compared to v2.1.6:
```diff
--- a/coucharchive
+++ b/coucharchive
@@ -34,7 +34,7 @@ import urllib.request
 import couchdb

-MAX_NUMBER_OF_WORKERS = 128
+MAX_NUMBER_OF_WORKERS = 64

 def _canonical_couchdb_url(url):
@@ -296,7 +296,7 @@ class ReplicationControl(object):
         if not len(self._last_successes):
             # We do not have enough data yet to return anything useful.
             # Start with 4 concurrent replications:
-            return 4
+            return 64
         else:
             # Compute the ideal number of concurrent replications, to finish in
             # ideal_duration:
```

[`feat(replication): Implement queues and replication controller`]: https://github.com/adrienverge/coucharchive/commit/45fbdd5