### PR TITLE
feat(CouchDB): Create backups with max_dbs_open = 10000

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -174,7 +174,7 @@ class CouchDBInstance(object):
                     '[couchdb]\n'
                     'database_dir = %s\n' % self.datadir +
                     'view_index_dir = %s\n' % self.datadir +
-                    'max_dbs_open = 2000\n'
+                    'max_dbs_open = 10000\n'
                     '\n'
                     '[cluster]\n'
                     'q=1\n'  # ideal for a small, 1-node setup


### PR DESCRIPTION
Raise value from 2000 to 10000 in saved backups, otherwise for large
backups:

    couchdb.http.ServerError: (500, ('internal_server_error', 'No DB shards could be opened.'))