### PR TITLE
feat(replication): Set `MAX_NUMBER_OF_WORKERS` to 64

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -34,7 +34,7 @@ import urllib.request
 import couchdb
 
 
-MAX_NUMBER_OF_WORKERS = 128
+MAX_NUMBER_OF_WORKERS = 64
 
 
 def _canonical_couchdb_url(url):


### PR DESCRIPTION
Following test over a few days, 128 workers seems too much for a cluster with
100k DBs, hosted on VMs with 2 CPU and 8GB RAM.
With that configuration, instability (CouchDB 500 error or HTTP timeout) start
to happen.

I propose to lower the value to 64 workers maximum.