### PR TITLE
feat(CouchDB): Disable CouchDB v3 compaction

### DIFF
--- a/coucharchive
+++ b/coucharchive
@@ -183,6 +183,10 @@ class CouchDBInstance(object):
                     'connection_timeout = 120000\n'  # avoid req_timedout
                     'worker_processes = 1\n'
                     '\n'
+                    '[smoosh]\n'
+                    'db_channels = ,\n'
+                    'view_channels = ,\n'
+                    '\n'
                     '[admins]\n'
                     '%s = %s\n' % self.creds)
 


### PR DESCRIPTION
Before in log, each two minutes:
```
--- ratio_dbs: Starting compaction for _dbs (priority 9.15040263830604)
--- Starting compaction for db "_dbs" at 303
```
After, still in log, no more compaction trace.

To test it I create an archive from CouchDB with many small databases as source,
and let it run for 6 minutes.

TODO: add performance impact on a full big cluster archive creation.